### PR TITLE
More Bingo Stuff

### DIFF
--- a/bingo_maingame.JSON
+++ b/bingo_maingame.JSON
@@ -49,14 +49,21 @@ bingoList[0] = [
   { name: "12 Grazer Dummies", types: ["dummies"] },
   { name: "All Grazer Dummies", types: ["dummies"] },
   
-  { name: "3 Blazing Suns", types: ["hgrounds"] },
-  { name: "6 Blazing Suns", types: ["hgrounds"] },
+  { name: "Nora Hunting Grounds Set", types: ["hgrounds"] },
+  { name: "Valleymeet Hunting Grounds Set", types: ["hgrounds"] },
+  { name: "Greatrun Hunting Grounds Set", types: ["hgrounds"] },
+  { name: "Spurflints Hunting Grounds Set", types: ["hgrounds"] },
+  { name: "Sun Furrows Hunting Grounds Set", types: ["hgrounds"] },
   { name: "9 Blazing Suns", types: ["hgrounds"] },
+  { name: "All Blazing Suns", types: ["hgrounds"] },
   
+  { name: "Bandit Camp Devil's Thirst", types: ["bcamps"] },
+  { name: "Bandit Camp Two-Teeth", types: ["bcamps"] },
+  { name: "Bandit Camp Hollow Fort", types: ["bcamps"] },
+  { name: "Bandit Camp Gatelands", types: ["bcamps"] },
+  { name: "Bandit Camp Blackwing Snag", types: ["bcamps"] },
+  { name: "Bandit Camp Shattered Kiln", types: ["bcamps"] },
   { name: "3 Bandit Camps", types: ["bcamps"] },
-  { name: "4 Bandit Camps", types: ["bcamps"] },
-  { name: "5 Bandit Camps", types: ["bcamps"] },
-  { name: "6 Bandit Camps", types: ["bcamps"] },
   { name: "All Bandit Camps", types: ["bcamps"] },
   
   { name: "Cauldron SIGMA", types: ["cauldrons"] },
@@ -66,13 +73,22 @@ bingoList[0] = [
   { name: "Cauldron EPSILON", types: ["cauldrons"] },
   { name: "All Cauldrons", types: ["cauldrons"] },
   
-  { name: "2 Tallnecks", types: ["tallnecks"] },
+  { name: "Tallneck Rustwash", types: ["tallnecks"] },
+  { name: "Tallneck Copper Deeps", types: ["tallnecks"] },
+  { name: "Tallneck Sun-Steps", types: ["tallnecks"] },
+  { name: "Tallneck Spearshafts", types: ["tallnecks"] },
+  { name: "Tallneck Devil's Thirst", types: ["tallnecks"] },
   { name: "3 Tallnecks", types: ["tallnecks"] },
-  { name: "4 Tallnecks", types: ["tallnecks"] },
+  { name: "All Tallnecks", types: ["tallnecks"] },
   
   { name: "Obtain Shieldweaver", types: ["sidequest"] },
   { name: "Complete 'Traitor's Bounty'", types: ["sidequest"] },
   { name: "Complete 'Queen's Gambit'", types: ["sidequest"] }, 
+  { name: "Complete 'Cause For Concern - Farewell'", types: ["sidequest, bcamps"] }, 
+  { name: "Complete 'In Her Mother's Footsteps'", types: ["sidequest"] }, 
+  { name: "Complete 'The Forgotten'", types: ["sidequest"] }, 
+  
+  { name: "Complete 'Odd Grata'", types: ["errand"] }, 
   
 ];
 

--- a/bingo_maingame.JSON
+++ b/bingo_maingame.JSON
@@ -46,19 +46,12 @@ bingoList[0] = [
   { name: "Complete 'Into the Borderlands'", types: ["carjamain"] },
   { name: "Complete 'The Sun Shall Fall'", types: ["carjamain"] },
   
-  { name: "5 Grazer Dummies", types: ["dummies"] },
-  { name: "10 Grazer Dummies", types: ["dummies"] },
-  { name: "15 Grazer Dummies", types: ["dummies"] },
+  { name: "12 Grazer Dummies", types: ["dummies"] },
   { name: "All Grazer Dummies", types: ["dummies"] },
   
   { name: "3 Blazing Suns", types: ["hgrounds"] },
   { name: "6 Blazing Suns", types: ["hgrounds"] },
   { name: "9 Blazing Suns", types: ["hgrounds"] },
-  
-  { name: "3 Ancient Vessels", types: ["avessels"] },
-  { name: "6 Ancient Vessels", types: ["avessels"] },
-  { name: "9 Ancient Vessels", types: ["avessels"] },
-  { name: "All Ancient Vessels", types: ["avessels"] },
   
   { name: "3 Bandit Camps", types: ["bcamps"] },
   { name: "4 Bandit Camps", types: ["bcamps"] },
@@ -66,9 +59,12 @@ bingoList[0] = [
   { name: "6 Bandit Camps", types: ["bcamps"] },
   { name: "All Bandit Camps", types: ["bcamps"] },
   
-  { name: "1 Cauldron", types: ["cauldrons"] },
-  { name: "2 Cauldrons", types: ["cauldrons"] },
-  { name: "3 Cauldrons", types: ["cauldrons"] },
+  { name: "Cauldron SIGMA", types: ["cauldrons"] },
+  { name: "Cauldron XI", types: ["cauldrons"] },
+  { name: "Cauldron ZETA", types: ["cauldrons"] },
+  { name: "Cauldron RHO", types: ["cauldrons"] },
+  { name: "Cauldron EPSILON", types: ["cauldrons"] },
+  { name: "All Cauldrons", types: ["cauldrons"] },
   
   { name: "2 Tallnecks", types: ["tallnecks"] },
   { name: "3 Tallnecks", types: ["tallnecks"] },

--- a/bingo_maingame.JSON
+++ b/bingo_maingame.JSON
@@ -46,6 +46,37 @@ bingoList[0] = [
   { name: "Complete 'Into the Borderlands'", types: ["carjamain"] },
   { name: "Complete 'The Sun Shall Fall'", types: ["carjamain"] },
   
+  { name: "5 Grazer Dummies", types: ["dummies"] },
+  { name: "10 Grazer Dummies", types: ["dummies"] },
+  { name: "15 Grazer Dummies", types: ["dummies"] },
+  { name: "All Grazer Dummies", types: ["dummies"] },
+  
+  { name: "3 Blazing Suns", types: ["hgrounds"] },
+  { name: "6 Blazing Suns", types: ["hgrounds"] },
+  { name: "9 Blazing Suns", types: ["hgrounds"] },
+  
+  { name: "3 Ancient Vessels", types: ["avessels"] },
+  { name: "6 Ancient Vessels", types: ["avessels"] },
+  { name: "9 Ancient Vessels", types: ["avessels"] },
+  { name: "All Ancient Vessels", types: ["avessels"] },
+  
+  { name: "3 Bandit Camps", types: ["bcamps"] },
+  { name: "4 Bandit Camps", types: ["bcamps"] },
+  { name: "5 Bandit Camps", types: ["bcamps"] },
+  { name: "6 Bandit Camps", types: ["bcamps"] },
+  { name: "All Bandit Camps", types: ["bcamps"] },
+  
+  { name: "1 Cauldron", types: ["cauldrons"] },
+  { name: "2 Cauldrons", types: ["cauldrons"] },
+  { name: "3 Cauldrons", types: ["cauldrons"] },
+  
+  { name: "2 Tallnecks", types: ["tallnecks"] },
+  { name: "3 Tallnecks", types: ["tallnecks"] },
+  { name: "4 Tallnecks", types: ["tallnecks"] },
+  
+  { name: "Obtain Shieldweaver", types: ["sidequest"] },
+  { name: "Complete 'Traitor's Bounty'", types: ["sidequest"] },
+  { name: "Complete 'Queen's Gambit'", types: ["sidequest"] }, 
   
 ];
 


### PR DESCRIPTION
Added:

Grazer Dummies: 5, 10, 15 and All.
Blazing Suns: 3, 6 and 9.
Ancient Vessels: 3, 6, 9 and All.
Bandit Camps: 3, 4, 5, 6 and All.
Cauldrons: 1, 2 and 3.
Tallnecks: 2, 3 and 4.
Sidequests: ShieldWeaver, Traitor's Bounty and Queen's Gambit.